### PR TITLE
Fix broken link in navbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
 				<span class="nav-link"><a href="#projects">Projects</a><img
 						src="media/icons/keyboard-arrow-down_2.svg" alt=""></span>
 				<ul>
-					<li><a href="#devcade"></a>Devcade</li>
+					<li><a href="#devcade">Devcade</a></li>
 					<li><a href="#bankshot">BankShot</a></li>
 					<li><a href="#void-break">Void Break</a></li>
 					<li><a href="#factorio-library">Factorio Library</a></li>


### PR DESCRIPTION
<!-- _Please make sure to review and check all of these items: -->

###Description:

As the title says, this simply fixes a formatting error that broke the devcade link in the navbar projects dropdown.


###Changes:

- [x] Moved closing tag to enclose the text


###Final checks:

Skipping as no content was changed

- [ ] Run modified section through spell/grammar check and proof read.
- [ ] Preview changes in browser to ensure nothing is broken.
- [ ] Ready to go public.
